### PR TITLE
Fix typo in nav

### DIFF
--- a/frontend/templates/partials/header.hbs
+++ b/frontend/templates/partials/header.hbs
@@ -4,7 +4,7 @@
   <input id="header-items-toggle" class="option-checkbox" type="checkbox"/>
   <nav role="navigation" class="header-items">
     <a class="header-item" href="/download">Download</a>
-    <a class="header-item" href="/">Documentaion</a>
+    <a class="header-item" href="/">Documentation</a>
     <a class="header-item" href="/news">News</a>
     <a class="header-item" href="/">Resources</a>
   </nav>


### PR DESCRIPTION
Just fixing the misspelling of "documentation" in the navbar. 