### PR TITLE
fontfaceobserver and js/build.js issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ frontend/lib
 frontend/css
 frontend/js/prod.js*
 frontend/js/*.custom.js
+frontend/js/build.js
 modernizr-metadata.json
-index.js

--- a/frontend/templates/partials/footer.hbs
+++ b/frontend/templates/partials/footer.hbs
@@ -17,7 +17,7 @@
 <a class="hiddentext" title="Check out the code on github" href="https://github.com/modernizr/modernizr">Check out the code on github</a>
 </footer>
 
-<script async src="/js/index.js"></script>
+<script async src="/js/build.js"></script>
 <script async>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Hey, this actually reverts some changes made in f7625b67277455d3a85a15bc0499dcbb53aad7e6

The source file (`js/index.js`) was being directly linked in the HTML, which was causing errors due to `require()` being undefined. So I've made sure it now links to the built copy `js/build.js`, which is a file that gets compiled with browserify in `gulp:global_browserify` and copied to `dist` in `gulp:copy-scripts`.

Fonts now work again locally, but I assume the change was made because they weren't working in production? @patrickkettner can you provide any context here?