### PR TITLE
Post to codepen via https to avoid security prompt

### DIFF
--- a/frontend/js/download/DownloadOverlay.js
+++ b/frontend/js/download/DownloadOverlay.js
@@ -66,7 +66,7 @@ var DownloadOverlay = React.createClass({
             key: 'codepen'
           },
             form({
-              action: 'http://codepen.io/pen/define',
+              action: 'https://codepen.io/pen/define',
               method: 'POST'
             },
               input({


### PR DESCRIPTION
Stops the browser complaining about an insecure post. See #18.