### PR TITLE
Fixes `npm run develop` infinite loop

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -376,7 +376,8 @@ gulp.task('develop', function () {
       'frontend/lib',
       'frontend/css',
       'frontend/js/*.custom.js',
-      'frontend/js/download/downloader.js'
+      'frontend/js/download/downloader.js',
+      'frontend/js/build.js'
     ]
   })
     .on('start', tasks)


### PR DESCRIPTION
I cloned a fresh copy of the site, and came across the same issue as @KuraFire, where the build would infinitely loop as files were being watched.

I think `js/build.js` just needed adding to the nodemon ignore array.

cc @patrickkettner, to check i'm not doing this wrong :dancers: 