### PR TITLE
Grid layouts for desktop screens

### DIFF
--- a/frontend/js/download/DetectList.js
+++ b/frontend/js/download/DetectList.js
@@ -3,6 +3,8 @@ var React = require('react/addons');
 var PureRenderMixin = React.addons.PureRenderMixin;
 var Detect = React.createFactory(require('./Detect'));
 var DOM = React.DOM, ul = DOM.ul, li = DOM.li;
+var cx = require('classnames');
+
 var DetectList = React.createClass({
   mixins: [PureRenderMixin],
 
@@ -68,7 +70,10 @@ var DetectList = React.createClass({
 
     detects = detects.length ? detects : li({className: 'detect option none'}, ':[ no such luck...');
 
-    return ul({className: 'detects'}, detects);
+    return ul({className: cx({
+      'detects': true,
+      'detectsGrid': !self.props.currentSearch
+    })}, detects);
   }
 });
 

--- a/frontend/js/download/DownloadUI.js
+++ b/frontend/js/download/DownloadUI.js
@@ -69,7 +69,8 @@ var DownloadUI = React.createClass({
         DetectList({
           ref: 'detectList',
           detects: detects,
-          select: this.select
+          select: this.select,
+          currentSearch: search
         })
        )
     );

--- a/frontend/styl/builder/detect.styl
+++ b/frontend/styl/builder/detect.styl
@@ -22,10 +22,10 @@
     display: block
     position: relative
     height: $DetectHeight
-    font-size: 1.4em
+    font-size: 1.2em
     line-height: $DetectHeight
     overflow: hidden
-    padding-right: $DetectHeight
+    padding-right: $DetectHeight + 10px
     padding-left: 1.2em
     width: 100%
     text-overflow: ellipsis
@@ -43,6 +43,19 @@
 
   &:first-child {
     border-top: none
+  }
+}
+
+.detectsGrid .detectRow {
+  display: inline-block
+  vertical-align: top
+  border-left: $lightBorder
+  width: 100%
+  @media (min-width: $XLargeScreen + 1px) {
+    width: 50%
+  }
+  @media (min-width: $XXLargeScreen + 1px) {
+    width: 33.33%;
   }
 }
 
@@ -66,7 +79,7 @@
   color: #444
 }
 
-@media (max-width: $XLargeScreen) {
+@media (max-width: $largeScreen) {
   .detects {
     margin-right: 0
   }

--- a/frontend/styl/builder/detect.styl
+++ b/frontend/styl/builder/detect.styl
@@ -25,8 +25,11 @@
     font-size: 1.2em
     line-height: $DetectHeight
     overflow: hidden
-    padding-right: $DetectHeight + 10px
-    padding-left: 1.2em
+    padding-right: 1.2em
+    padding-left: $DetectHeight + 10px
+    @media screen and (max-width: $smallScreen) {
+      padding-left: 50px
+    }
     width: 100%
     text-overflow: ellipsis
     white-space: nowrap
@@ -47,6 +50,9 @@
   vertical-align: top
   border-left: $lightBorder
   width: 100%
+  @media (min-width: $mediumScreen + 1px) and (max-width: $largeScreen) {
+    width: 50%
+  }
   @media (min-width: $XLargeScreen + 1px) {
     width: 50%
   }
@@ -90,12 +96,6 @@
 @media (max-width: $mediumScreen) {
   .detects {
     margin: (($HeaderButtonHeight * 4) + $StatsHeight) 0 0
-  }
-}
-
-@media (max-width: 550px) {
-  .detect {
-    font-size: 20px
   }
 }
 

--- a/frontend/styl/builder/detect.styl
+++ b/frontend/styl/builder/detect.styl
@@ -1,5 +1,5 @@
 .detects {
-  margin: $HeaderHeight + $StandardPadding 30% $StandardPadding 290px
+  margin: ($HeaderHeight + $StandardPadding - 1px) 30% $StandardPadding 290px
 }
 
 .option {
@@ -40,10 +40,6 @@
 
 .detectRow {
   border-top: $lightBorder
-
-  &:first-child {
-    border-top: none
-  }
 }
 
 .detectsGrid .detectRow {
@@ -55,7 +51,7 @@
     width: 50%
   }
   @media (min-width: $XXLargeScreen + 1px) {
-    width: 33.33%;
+    width: 33.33%
   }
 }
 
@@ -75,7 +71,7 @@
 .option-label:hover,
 .expanded .detect,
 .detect:hover {
-  background: $White;
+  background: $White
   color: #444
 }
 

--- a/frontend/styl/builder/leftColumn.styl
+++ b/frontend/styl/builder/leftColumn.styl
@@ -12,14 +12,21 @@
   .toggle {
     width: 1.2em
     top: 0
-    right: 0
-    padding-right: 0
+    left: 0
+    padding-left: 0
   }
 
   .option {
     display: block
     overflow: hidden
     line-height: 24px
+  }
+
+  .option-label {
+    padding-left: 25px
+    @media screen and (max-width: $largeScreen) {
+     padding-left: 35px
+    }
   }
 
   .option-separator {

--- a/frontend/styl/builder/metadataColumn.styl
+++ b/frontend/styl/builder/metadataColumn.styl
@@ -22,7 +22,7 @@
   display: block
 }
 
-@media (max-width: $XLargeScreen) {
+@media (max-width: $largeScreen) {
   .metadataColumn {
     position: static
     overflow: visible

--- a/frontend/styl/builder/toggle.styl
+++ b/frontend/styl/builder/toggle.styl
@@ -17,11 +17,11 @@
 .detectToggle {
   position: absolute
   top: 0
-  right: 0
+  left: 0
   height: 100%
   width: 40px
   box-sizing: content-box
-  padding: 0 20px
+  padding: 0 15px
 
   path {
     transition: all 0.3s
@@ -87,6 +87,7 @@
 
 @media (max-width: $smallScreen) {
   .detectToggle {
-    width: 46px
+    width: 30px
+    padding: 0 10px
   }
 }

--- a/frontend/styl/builder/toggle.styl
+++ b/frontend/styl/builder/toggle.styl
@@ -19,7 +19,7 @@
   top: 0
   right: 0
   height: 100%
-  width: 56px
+  width: 40px
   box-sizing: content-box
   padding: 0 20px
 

--- a/frontend/styl/vars.styl
+++ b/frontend/styl/vars.styl
@@ -19,9 +19,10 @@ $FooterHeight       = 150px
 $TransitionHeight   = 200px
 $TransitionDuration = 0.3s
 
-$DetectHeight = 88px
+$DetectHeight = 60px
 $StatsHeight  = $DetectHeight
 
+$XXLargeScreen = 1500px
 $XLargeScreen = 1250px
 $largeScreen  = 960px
 $mediumScreen = 750px

--- a/frontend/styl/vars.styl
+++ b/frontend/styl/vars.styl
@@ -20,7 +20,7 @@ $TransitionHeight   = 200px
 $TransitionDuration = 0.3s
 
 $DetectHeight = 60px
-$StatsHeight  = $DetectHeight
+$StatsHeight  = 70px
 
 $XXLargeScreen = 1500px
 $XLargeScreen = 1250px


### PR DESCRIPTION
Following up from issue #30, here are some changes:

— XXLarge (new breakpoint) has a 3-col layout
— XLarge has a 2-col layout
— Large now has right-hand column (as opposed to accordion layout)

Grid layouts are disabled when a user is searching, for a more common layout for search results.

<img width="1443" alt="2-col xlarge" src="https://cloud.githubusercontent.com/assets/24449/9888398/cbf08d5e-5bec-11e5-9984-4b554296ee86.png">
<img width="1792" alt="3-col xxlarge" src="https://cloud.githubusercontent.com/assets/24449/9888399/cbf71b7e-5bec-11e5-94ad-220cf5d87719.png">
<img width="1085" alt="right-col xlarge" src="https://cloud.githubusercontent.com/assets/24449/9888400/cbfa5578-5bec-11e5-91af-83f5d618d703.png">
