### PR TITLE
Ensure builder footer goes under the builder sidebars - fixes #35

### DIFF
--- a/frontend/styl/builder/detect.styl
+++ b/frontend/styl/builder/detect.styl
@@ -1,5 +1,5 @@
 .detects {
-  margin: $HeaderHeight + $StandardPadding 30% $StandardPadding 290px
+  margin: $HeaderHeight + 1 30% $StandardPadding $SidebarWidth
 }
 
 .option {

--- a/frontend/styl/builder/header.styl
+++ b/frontend/styl/builder/header.styl
@@ -41,7 +41,7 @@
   position: fixed
   top: $HeaderHeight
   right: 0
-  left: 290px
+  left: $SidebarWidth
   z-index: 2
   display: flex
   height: 0
@@ -54,9 +54,8 @@
 
 .header-search-input {
   padding: 0 1em
-  height: 100%
   border: 0
-  border-right: 10px solid #272727
+  margin-top: 1px
   font-style: italic
   flex: 3
   font-size: 1.2em

--- a/frontend/styl/builder/leftColumn.styl
+++ b/frontend/styl/builder/leftColumn.styl
@@ -3,7 +3,7 @@
 
   position: fixed
   top: $HeaderHeight + $StandardPadding
-  bottom: $StandardPadding
+  bottom: 0
   margin-right: $StandardPadding
   width: 260px
   overflow: scroll
@@ -150,6 +150,12 @@
 .leftColumn-checked {
   display: flex
   justify-content: space-between
+}
+
+@media (min-width: $largeScreen + 1px) {
+  .builder .leftColumn {
+    z-index: 2
+  }
 }
 
 @media (max-width: $mediumScreen) {

--- a/frontend/styl/builder/leftColumn.styl
+++ b/frontend/styl/builder/leftColumn.styl
@@ -2,12 +2,14 @@
   @extend $hiddenScrollbar
 
   position: fixed
-  top: $HeaderHeight + $StandardPadding
+  top: $HeaderHeight + 1
   bottom: 0
   margin-right: $StandardPadding
-  width: 260px
-  overflow: scroll
+  width: $SidebarWidth - 1
   transition: top $TransitionDuration
+  display: flex
+  flex-direction: column
+  background-color: $White
 
   .toggle {
     width: 1.2em
@@ -70,7 +72,10 @@
 
 .leftColumn-options {
   padding: 0 24px 12px
+  padding-bottom: $StandardPadding
   background: $White
+  flex: 1
+  overflow-y: auto
 }
 
 .classPrefix {

--- a/frontend/styl/builder/metadataColumn.styl
+++ b/frontend/styl/builder/metadataColumn.styl
@@ -22,6 +22,12 @@
   display: block
 }
 
+@media (min-width: $largeScreen + 1px) {
+  .builder .metadataColumn {
+    z-index: 2
+  }
+}
+
 @media (max-width: $XLargeScreen) {
   .metadataColumn {
     position: static

--- a/frontend/styl/components.styl
+++ b/frontend/styl/components.styl
@@ -5,7 +5,7 @@
 
 .column .box {
   border-top: $lightBorder
-  padding: 12px 24px
+  padding: 20.5px 24px
   background: $White
 }
 

--- a/frontend/styl/footer.styl
+++ b/frontend/styl/footer.styl
@@ -5,7 +5,7 @@
   min-height: $FooterHeight
   background: $ModernizrPink
   color: $BackgroundGrey
-  font-size: 20px
+  font-size: 16px
   line-height: 1.6
   justify-content: space-between
   align-items: flex-end
@@ -41,6 +41,13 @@
   width: 100%
   &>div {
     margin: 0.5em 0
+  }
+}
+
+@media (min-width: $largeScreen + 1px) {
+  .builder .footer {
+    padding-left: 290px
+    padding-right: 30%
   }
 }
 

--- a/frontend/styl/footer.styl
+++ b/frontend/styl/footer.styl
@@ -46,7 +46,12 @@
 
 @media (min-width: $largeScreen + 1px) {
   .builder .footer {
-    padding-left: 290px
+    padding-left: calc(290px + 1.2em * 1.4)
+  }
+}
+
+@media (min-width: $XLargeScreen + 1px) {
+  .builder .footer {
     padding-right: 30%
   }
 }

--- a/frontend/styl/header.styl
+++ b/frontend/styl/header.styl
@@ -7,7 +7,7 @@
 
 .header-logo {
   display: flex
-  min-width: 290px
+  min-width: $SidebarWidth
   background: $White
   justify-content: center
   align-items: center

--- a/frontend/styl/vars.styl
+++ b/frontend/styl/vars.styl
@@ -15,6 +15,7 @@ $HeaderHeight       = $HeaderButtonHeight * 2
 $SmallHeaderHeight  = 70px
 $StandardPadding    = 30px
 $FooterHeight       = 150px
+$SidebarWidth = 290px
 
 $TransitionHeight   = 200px
 $TransitionDuration = 0.3s


### PR DESCRIPTION
Here's a suggested improvement when you scroll to the bottom of the builder on shallow desktop viewports. We use an alternative footer treatment, so the contents of the footer is aligned to the detect rows, as opposed to the viewport; and the sidebars overlap the footer.

**Example of shallow viewport**

<img width="1686" alt="screen shot 2015-09-20 at 15 48 23" src="https://cloud.githubusercontent.com/assets/24449/9981245/b4afcba2-5faf-11e5-8b28-0665e369fd7f.png">
