### PR TITLE
Preserve old build urls that contain aliased names

### DIFF
--- a/frontend/js/download/index.js
+++ b/frontend/js/download/index.js
@@ -32,6 +32,7 @@ if (location.hash.length || location.search.length) {
           if (query === prop.toLowerCase()
              || query === 'shiv' && prop === 'html5shiv'
              || query === 'printshiv' && prop === 'html5printshiv'
+             || obj.builderAliases && _.contains(obj.builderAliases, query)
              || query === 'do_not_use_in_production') {
             obj.checked = true;
             return true;


### PR DESCRIPTION
E.g. modernizr.com/download/?file_api removes file_api as `file_api` -> `filereader`.

This will replace the name in the url and keep their tests intact. Solves #33.