### PR TITLE
Fixes #56 (https://github.com/Modernizr/modernizr-neue/issues/56)

### DIFF
--- a/frontend/js/download/DownloadOverlay.js
+++ b/frontend/js/download/DownloadOverlay.js
@@ -34,7 +34,7 @@ var DownloadOverlay = React.createClass({
             toggleTextarea: this.toggleTextarea,
             hasFlash: hasFlash,
             type: 'text/javascript',
-            filename: 'modernizr-custom',
+            filename: 'modernizr-custom.js',
             updateAction: props.updateAction,
             key: 'build'
           }),
@@ -45,7 +45,7 @@ var DownloadOverlay = React.createClass({
             toggleTextarea: this.toggleTextarea,
             hasFlash: hasFlash,
             type: 'application/json',
-            filename: 'modernizr-config',
+            filename: 'modernizr-config.json',
             path: '/download/config',
             updateAction: props.updateAction,
             key: 'config'
@@ -57,7 +57,7 @@ var DownloadOverlay = React.createClass({
             toggleTextarea: this.toggleTextarea,
             hasFlash: hasFlash,
             type: 'application/json',
-            filename: 'grunt config',
+            filename: 'grunt-config.json',
             path: '/download/gruntconfig',
             updateAction: props.updateAction,
             key: 'grunt'


### PR DESCRIPTION
We need to specify the file extension explicitly inside the HTML5
download attribute since the HREF attribute doesn't point to an actual
file, rather a JS blob, this trips up browsers when they are trying to
interpret the file type - even though this has been specified in the
setup.

Also fixed up grunt config file for consistency with the other two file
names.