### PR TITLE
Added property name to metadata - refs #66

### DIFF
--- a/frontend/js/download/CodeExampleModal.js
+++ b/frontend/js/download/CodeExampleModal.js
@@ -7,50 +7,32 @@ var CodeExampleModal = React.createClass({
     var data = this.props.data;
 
     return div({
+      className: 'modal',
       onClick: function() {
         this.props.onRequestClose();
-      }.bind(this),
-      style: {
-        position: 'fixed',
-        top: 0, right: 0, bottom: 0, left: 0,
-        backgroundColor: 'rgba(255, 255, 255, 0.8)',
-        zIndex: 2,
-        overflow: 'auto',
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'center'
-      }
+      }.bind(this)
     },
       div({
+        className: 'modal-inner',
         onClick: function(e) {
           e.stopPropagation();
-        }.bind(this),
-        style: {
-          boxShadow: '0px 10px 30px rgba(0, 0, 0, 0.2)',
-          padding: 20,
-          backgroundColor: '#fff',
-          width: '100%',
-          maxWidth: 500,
-          overflow: 'auto',
-          lineHeight: '1.5em'
-        }
+        }.bind(this)
       },
-        span({style: {opacity: 0.5}}, 'CSS'),
-        pre({style: {overflow: 'visible'}},
-          '.no-' + data.property + ' .box { color: red; }\n' +
-          '.' + data.property + ' .box { color: green; }\n'
-        ),
-        span({style: {opacity: 0.5}}, 'JS'),
-        pre({style: {overflow: 'visible'}},
-          (data.async ? 'Modernizr.on(\'' + data.property + '\', function (result) {\n' : '') +
-          'if (' + (data.async ? 'result' : ('Modernizr.' + data.property)) + ') {\n' +
-          '// supported\n' +
-          '} else {\n' +
-          '  // not-supported\n' +
-          '}\n' +
+        span({className: 'note'}, 'CSS'),
+        pre({className: 'codeblock', dangerouslySetInnerHTML: {__html:
+          '<span class="pl-e">.no-' + data.property + ' .box</span> { <span class="pl-c1">color: red;</span> }\n' +
+          '<span class="pl-e">.' + data.property + ' .box</span> { <span class="pl-c1">color: green;</span> }\n'
+        }}),
+        span({className: 'note'}, 'JS'),
+        pre({className: 'codeblock', dangerouslySetInnerHTML: {__html:
+          (data.async ? '<span class="pl-smi">Modernizr</span>.<span class="pl-en">on</span>(<span class="pl-s">\'' + data.property + '\'</span>, <span class="pl-k">function</span>(<span class="pl-smi">result</span>) {\n' : '') +
+          (data.async ? '  ' : '') + '<span class="pl-k">if</span> (' + (data.async ? 'result' : ('Modernizr.<span class="pl-c1">' + data.property + '</span>')) + ') {\n' +
+          (data.async ? '  ' : '') + '  <span class="pl-c">// supported</span>\n' +
+          (data.async ? '  ' : '') + '} <span class="pl-k">else</span> {\n' +
+          (data.async ? '  ' : '') + '  <span class="pl-c">// not-supported</span>\n' +
+          (data.async ? '  ' : '') + '}\n' +
           (data.async ? '});' : '')
-        )
+        }})
       )
     )
   }

--- a/frontend/js/download/CodeExampleModal.js
+++ b/frontend/js/download/CodeExampleModal.js
@@ -1,0 +1,59 @@
+'use strict';
+var React = require('react/addons');
+var DOM = React.DOM, div = DOM.div, span = DOM.span, pre = DOM.pre;
+
+var CodeExampleModal = React.createClass({
+  render: function() {
+    var data = this.props.data;
+
+    return div({
+      onClick: function() {
+        this.props.onRequestClose();
+      }.bind(this),
+      style: {
+        position: 'fixed',
+        top: 0, right: 0, bottom: 0, left: 0,
+        backgroundColor: 'rgba(255, 255, 255, 0.8)',
+        zIndex: 2,
+        overflow: 'auto',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }
+    },
+      div({
+        onClick: function(e) {
+          e.stopPropagation();
+        }.bind(this),
+        style: {
+          boxShadow: '0px 10px 30px rgba(0, 0, 0, 0.2)',
+          padding: 20,
+          backgroundColor: '#fff',
+          width: '100%',
+          maxWidth: 500,
+          overflow: 'auto',
+          lineHeight: '1.5em'
+        }
+      },
+        span({style: {opacity: 0.5}}, 'CSS'),
+        pre({style: {overflow: 'visible'}},
+          '.no-' + data.property + ' .box { color: red; }\n' +
+          '.' + data.property + ' .box { color: green; }\n'
+        ),
+        span({style: {opacity: 0.5}}, 'JS'),
+        pre({style: {overflow: 'visible'}},
+          (data.async ? 'Modernizr.on(\'' + data.property + '\', function (result) {\n' : '') +
+          'if (' + (data.async ? 'result' : ('Modernizr.' + data.property)) + ') {\n' +
+          '// supported\n' +
+          '} else {\n' +
+          '  // not-supported\n' +
+          '}\n' +
+          (data.async ? '});' : '')
+        )
+      )
+    )
+  }
+});
+
+module.exports = CodeExampleModal;

--- a/frontend/js/download/Metadata.js
+++ b/frontend/js/download/Metadata.js
@@ -8,7 +8,8 @@ var MetadataPolyfills = React.createFactory(require('./MetadataPolyfills'));
 var util = require('./util');
 
 var listify = util.listify;
-var DOM = React.DOM, div = DOM.div, span = DOM.span;
+var DOM = React.DOM, div = DOM.div, span = DOM.span,
+  p = DOM.p, code = DOM.code, a = DOM.a;
 
 var Metadata = React.createClass({
   mixins: [PureRenderMixin],
@@ -30,11 +31,22 @@ var Metadata = React.createClass({
       div({className: 'metadataColumn column'},
         div({className: 'name box ' + (authors.length ? 'hasAuthors' : '')},
           span({className: 'heading'}, name),
-          (!_.isEmpty(authors) && div({className: 'subheading'}, 'By: ' + listify(authors))),
-          div({className: 'propertyname', dangerouslySetInnerHTML: {__html: '<code>' + property + '</code>'}})
+          (!_.isEmpty(authors) && div({className: 'subheading'}, 'By: ' + listify(authors)))
         ),
         (async && div({className: 'box metadata-async'}, 'This is an async detect')),
         (docs && MetadataDocs({docs: docs})),
+        div({className: 'name box'},
+          div({className: 'heading-small'}, 'Usage'),
+          div({className: 'propertyname'},
+            p(null, code(null, property)),
+            p(null, a({
+              onClick: function(e) {
+                e.preventDefault();
+                this.props.onViewExamplesClick();
+              }.bind(this)
+            }, 'View examples'))
+          )
+        ),
         (!_.isEmpty(polyfills) && MetadataPolyfills({polyfills: polyfills})),
         (!_.isEmpty(warnings) && MetadataList({keyBase: name + '-warning-', str: 'warning', items: warnings})),
         (!_.isEmpty(knownBugs) && MetadataList({keyBase: name + '-bug-', str: 'known bug', items: knownBugs})),

--- a/frontend/js/download/Metadata.js
+++ b/frontend/js/download/Metadata.js
@@ -23,13 +23,15 @@ var Metadata = React.createClass({
     var notes = data.notes;
     var polyfills = data.polyfills;
     var warnings = data.warnings;
+    var property = data.property;
 
 
     return (
       div({className: 'metadataColumn column'},
         div({className: 'name box ' + (authors.length ? 'hasAuthors' : '')},
           span({className: 'heading'}, name),
-          (!_.isEmpty(authors) && div({className: 'subheading'}, 'By: ' + listify(authors)))
+          (!_.isEmpty(authors) && div({className: 'subheading'}, 'By: ' + listify(authors))),
+          div({className: 'propertyname', dangerouslySetInnerHTML: {__html: '<code>' + property + '</code>'}})
         ),
         (async && div({className: 'box metadata-async'}, 'This is an async detect')),
         (docs && MetadataDocs({docs: docs})),

--- a/frontend/js/download/Option.js
+++ b/frontend/js/download/Option.js
@@ -2,9 +2,16 @@
 var React = require('react/addons');
 var SVGToggle = React.createFactory(require('./SVGToggle'));
 var Metadata = React.createFactory(require('./Metadata'));
+var CodeExampleModal = React.createFactory(require('./CodeExampleModal'));
 var DOM = React.DOM, div = DOM.div, input = DOM.input, label = DOM.label;
 
 var Option = React.createClass({
+
+  getInitialState: function() {
+    return {
+      isExamplesOpen: false
+    };
+  },
 
   render: function() {
     var props = this.props;
@@ -12,6 +19,8 @@ var Option = React.createClass({
     var value = data.amdPath || data.property;
     var prop = data.property;
     var name = data.name;
+
+
 
     return (
       div({className: props.className},
@@ -38,7 +47,25 @@ var Option = React.createClass({
             className: 'detectToggle'
           })
         ),
-        (props.metaData && Metadata({ref: 'metadata', data: data}))
+        (props.metaData && Metadata({
+          ref: 'metadata',
+          data: data,
+          onViewExamplesClick: function() {
+            this.setState({
+              isExamplesOpen: true
+            });
+          }.bind(this)
+        })),
+        (props.metaData && this.state.isExamplesOpen && (
+          CodeExampleModal({
+            data: data,
+            onRequestClose: function() {
+              this.setState({
+                isExamplesOpen: false
+              });
+            }.bind(this)
+          })
+        ))
       )
     );
   },

--- a/frontend/styl/builder/metadataColumn.styl
+++ b/frontend/styl/builder/metadataColumn.styl
@@ -23,7 +23,18 @@
 }
 
 .propertyname {
-  margin-top: 10px;
+  margin-top: 10px
+  p {
+    margin: 0.8em 0
+  }
+  a {
+    cursor: pointer
+  }
+}
+
+code {
+   padding: 5px
+   font-size: 0.8em
 }
 
 @media (min-width: $largeScreen + 1px) {

--- a/frontend/styl/builder/metadataColumn.styl
+++ b/frontend/styl/builder/metadataColumn.styl
@@ -22,6 +22,10 @@
   display: block
 }
 
+.propertyname {
+  margin-top: 10px;
+}
+
 @media (min-width: $largeScreen + 1px) {
   .builder .metadataColumn {
     z-index: 2

--- a/frontend/styl/components.styl
+++ b/frontend/styl/components.styl
@@ -85,3 +85,27 @@
     border-color: $DarkGrey
   }
 }
+
+.modal {
+  position: fixed
+  top: 0
+  right: 0
+  bottom: 0
+  left: 0
+  background-color: rgba(255, 255, 255, 0.8)
+  z-index: 2
+  overflow: auto
+  display: flex
+  flex-direction: row
+  align-items: center
+  justify-content: center
+}
+.modal-inner {
+  box-shadow: 0px 10px 30px rgba(0, 0, 0, 0.2)
+  padding: 20px
+  background-color: #fff
+  width: 100%
+  max-width: 500px
+  overflow: auto
+  line-height: 1.5em
+}

--- a/frontend/styl/main.styl
+++ b/frontend/styl/main.styl
@@ -8,3 +8,4 @@
 @require "home"
 @require "news"
 @require "docs"
+@require "syntax"

--- a/frontend/styl/syntax.styl
+++ b/frontend/styl/syntax.styl
@@ -1,0 +1,33 @@
+.pl-k {
+  color: #a71d5d
+}
+
+.pl-smi {
+  color: #333
+}
+
+.pl-c1, .pl-s .pl-v {
+  color: #0086b3
+}
+
+.pl-c {
+  color: #969896
+}
+
+.pl-e,
+.pl-en {
+  color: #795da3
+}
+
+.pl-s {
+  color: #183691;
+}
+
+.note {
+  color: #ccc;
+}
+
+.codeblock {
+  overflow: visible;
+  color: #333;
+}

--- a/server/buildSteps/download.js
+++ b/server/buildSteps/download.js
@@ -7,4 +7,4 @@ var downloadFactory = React.createFactory(DownloadModule);
 var options = require('../util/modernizrOptions');
 
 // render a static version of the `builder` for a faster inital render/script-less clients
-module.exports = null;//React.renderToString(downloadFactory({detects:Modernizr.metadata(), options: options}));
+module.exports = React.renderToString(downloadFactory({detects:Modernizr.metadata(), options: options}));

--- a/server/buildSteps/download.js
+++ b/server/buildSteps/download.js
@@ -7,4 +7,4 @@ var downloadFactory = React.createFactory(DownloadModule);
 var options = require('../util/modernizrOptions');
 
 // render a static version of the `builder` for a faster inital render/script-less clients
-module.exports = React.renderToString(downloadFactory({detects:Modernizr.metadata(), options: options}));
+module.exports = null;//React.renderToString(downloadFactory({detects:Modernizr.metadata(), options: options}));


### PR DESCRIPTION
This adds the property name in a `<code />` element, next to the detect title. This gives the benefit of not having to look up or guess the property when writing CSS or JS.

Refs #66 