### PR TITLE
Update gruntConfig in utils.js

### DIFF
--- a/frontend/js/download/util.js
+++ b/frontend/js/download/util.js
@@ -13,10 +13,9 @@ var pluralize = function(baseStr, arr) {
 
 var gruntify = function(config, metadata) {
   var gruntConfig = {
-    parseFiles: true,
+    crawl: false,
     customTests: [],
-    devFile: '/PATH/TO/modernizr-dev.js',
-    outputFile: '/PATH/TO/modernizr-output.js'
+    dest: '/PATH/TO/modernizr-output.js'
   };
   gruntConfig.tests = _.map(config['feature-detects'], function(amdPath) {
     var detect = _.find(metadata, function(detect) {


### PR DESCRIPTION
Changes made to provide compatibility with `grunt-modernizr`.
* Change `parseFiles` to `crawl` and default value to `false` to prevent looking for files to parse. Otherwise something like `"files" : {"src" : [ ... ] }` is required to have a working config.
* Changed destination file paths to use only `dest` as `devFile` and `outputFile` were ignored (a dev build would require a duplicate task with its own options).

Perhaps these should be changed in https://github.com/Modernizr/grunt-modernizr and/or https://github.com/Modernizr/customizr too?