### PR TITLE
stop assuming props are always strings

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -106,7 +106,7 @@ Say you include Modernizr's detection for CSS gradients. Depending on the browse
 
 #### classPrefix
 
-If you one of Modernizr's class names clashes with one of your preexisting classes, you have the option to add a `classPrefix` inside of [your config](#command-line-config). Consider the [hidden](https://github.com/Modernizr/Modernizr/blob/7b8c0f/feature-detects/dom/hidden.js) detect, which adds a `.hidden` class - something a lot of code bases already use to, well, _hide_ things. If you wanted to use that specific detection, you could use the following as your configuration
+If one of Modernizr's class names clashes with one of your preexisting classes, you have the option to add a `classPrefix` inside of [your config](#command-line-config). Consider the [hidden](https://github.com/Modernizr/Modernizr/blob/7b8c0f/feature-detects/dom/hidden.js) detect, which adds a `.hidden` class - something a lot of code bases already use to, well, _hide_ things. If you wanted to use that specific detection, you could use the following as your configuration
 
 ```json
 {

--- a/server/routes/download.js
+++ b/server/routes/download.js
@@ -43,7 +43,15 @@ var propToAMD = function(prop) {
     prop = prop.split('_');
   }
 
-  return _.where(modernizrMetadata, {'property': prop})[0].amdPath;
+  var detect = _.where(modernizrMetadata, {'property': prop});
+
+  if (_.isEmpty(detect)) {
+    // if the detect wasn't found, the property is probably inside of an array
+    // of differnet properties, which are typically used for back compat reasons
+    detect = _.where(modernizrMetadata, {'property': [prop]});
+  }
+
+  return detect && detect[0].amdPath;
 };
 
 var optProp = function(prop) {


### PR DESCRIPTION
fixes Modernizr/Modernizr#1929

the filtering code was silently failing when we look up several detects with
non string prop values.