### PR TITLE
CSS quickfix in header logo

### DIFF
--- a/frontend/styl/header.styl
+++ b/frontend/styl/header.styl
@@ -27,8 +27,7 @@
 }
 
 .header-logo a {
-  justify-content: flex-start
-  padding-left: 40px
+  justify-content: center
 }
 
 


### PR DESCRIPTION
Coming from the RWD Google docs, I couldn't help but notice the padding-left in the header logo was driving me nuts.