### PR TITLE
Fix FOUC occurring when FontFaceObserver detects font loaded

### DIFF
--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -1,8 +1,78 @@
-'use strict';
-require('fontfaceobserver/fontfaceobserver');
-
-new window.FontFaceObserver('Source Sans Pro', {})
-  .check()
-  .then(function() {
-    document.documentElement.className += ' font-loaded';
-  });
+// @see solution from Smashing Magazine: https://gist.github.com/hdragomir/8f00ce2581795fd7b1b7
+(function () {
+  "use strict";
+  // once cached, the css file is stored on the client forever unless
+  // the URL below is changed. Any change will invalidate the cache
+  var css_href = 'https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600';
+  // a simple event handler wrapper
+  function on(el, ev, callback) {
+    if (el.addEventListener) {
+      el.addEventListener(ev, callback, false);
+    } else if (el.attachEvent) {
+      el.attachEvent("on" + ev, callback);
+    }
+  }
+  
+  // if we have the fonts in localStorage or if we've cached them using the native batrowser cache
+  if ((window.localStorage && localStorage.font_css_cache) || document.cookie.indexOf('font_css_cache') > -1){
+    // just use the cached version
+    injectFontsStylesheet();
+  } else {
+   // otherwise, don't block the loading of the page; wait until it's done.
+    on(window, "load", injectFontsStylesheet);
+  }
+  
+  // quick way to determine whether a css file has been cached locally
+  function fileIsCached(href) {
+    return window.localStorage && localStorage.font_css_cache && (localStorage.font_css_cache_file === href);
+  }
+  // time to get the actual css file
+  function injectFontsStylesheet() {
+   // if this is an older browser
+    if (!window.localStorage || !window.XMLHttpRequest) {
+      var stylesheet = document.createElement('link');
+      stylesheet.href = css_href;
+      stylesheet.rel = 'stylesheet';
+      stylesheet.type = 'text/css';
+      document.getElementsByTagName('head')[0].appendChild(stylesheet);
+      // just use the native browser cache
+      // this requires a good expires header on the server
+      document.cookie = "font_css_cache";
+    
+    // if this isn't an old browser
+    } else {
+       // use the cached version if we already have it
+      if (fileIsCached(css_href)) {
+        injectRawStyle(localStorage.font_css_cache);
+      // otherwise, load it with ajax
+      } else {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", css_href, true);
+        // cater for IE8 which does not support addEventListener or attachEvent on XMLHttpRequest
+        xhr.onreadystatechange = function () {
+          if (xhr.readyState === 4) {
+            // once we have the content, quickly inject the css rules
+            injectRawStyle(xhr.responseText);
+            // and cache the text content for further use
+            // notice that this overwrites anything that might have already been previously cached
+            localStorage.font_css_cache = xhr.responseText;
+            localStorage.font_css_cache_file = css_href;
+          }
+        };
+        xhr.send();
+      }
+    }
+  }
+  // this is the simple utitily that injects the cached or loaded css text
+  function injectRawStyle(text) {
+    var style = document.createElement('style');
+    // cater for IE8 which doesn't support style.innerHTML
+    style.setAttribute("type", "text/css");
+    if (style.styleSheet) {
+        style.styleSheet.cssText = text;
+    } else {
+        style.innerHTML = text;
+    }
+    document.getElementsByTagName('head')[0].appendChild(style);
+  }
+}());

--- a/frontend/styl/base.styl
+++ b/frontend/styl/base.styl
@@ -1,12 +1,8 @@
 html {
   box-sizing: border-box
-  font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif
+  font-family: 'Source Sans Pro', 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif
   min-width: 320px
   color: $Black
-
-  &.font-loaded {
-    font-family: 'Source Sans Pro', 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif
-  }
 }
 
 *, *:before, *:after {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "browserify": "^9.0.3",
     "classnames": "2.1.1",
     "etag": "^1.5.1",
-    "fontfaceobserver": "^1.4.2",
     "fuse.js": "^1.2.2",
     "globby": "^4.0.0",
     "handlebars": "^3.0.0",


### PR DESCRIPTION
So there is this little issue with FOUC taking place when navigating through docs website. I found this solution https://gist.github.com/hdragomir/8f00ce2581795fd7b1b7 that Smashing Magazine uses which seems to keep good performance without having this ugly font switch. Additionally I got rid of `FontFaceObserver`. Let me know what you think. 🤔 